### PR TITLE
BestRecord & BasicCounter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.1.0
+
+### **New services added**:
+
+- 🏅 **BestRecord** — track the best (max or min) performance or value over time, with a full history and fallback support
+  → Example use cases: high scores, fastest times, highest streaks
+
+- 🔢 **BasicCounter** — a simple persistent counter with no expiration or alignment
+  → Example use cases: total taps, visits, or actions
+
+### **Enhancements**:
+
+- 🔥 **StreakTracker now integrates BestRecord**
+  - Automatically tracks and saves the highest streak ever achieved
+  - Supports history length, fallback records, and customizable record mode (`max` or `min`)
+
+### Fixed:
+
+- **Synchronized `clearValueOnly()` in BaseCounterService**  
+  Now uses `_lock.synchronized()` to prevent race conditions, ensuring thread safety like `increment()` and `reset()`.
+
 ## 1.0.0
 
 ### ✨ **`track` initial release**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ### **New services added**:
 
-- 🏅 **BestRecord** — track the best (max or min) performance or value over time, with a full history and fallback support
-  → Example use cases: high scores, fastest times, highest streaks
+- 🏅 **BestRecord** — track the best (max or min) performance or value over time, with a full history and fallback support. Example use cases: high scores, fastest times, highest streaks
 
-- 🔢 **BasicCounter** — a simple persistent counter with no expiration or alignment
-  → Example use cases: total taps, visits, or actions
+- 🔢 **BasicCounter** — a simple persistent counter with no expiration or alignment. Example use cases: total taps, visits, or actions
 
 ### **Enhancements**:
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+import 'package:track/track.dart';
+
+Future<void> main() async {
+  // ✅ Create a daily streak tracker
+  final streak = StreakTracker(
+    'daily_exercise',
+    period: TimePeriod.daily,
+    recordsHistory: 3,
+  );
+
+  // ⚡ Bump the streak (mark today as completed)
+  await streak.bump();
+  debugPrint('Streak bumped!');
+
+  // 📊 Get the current streak count
+  final current = await streak.currentStreak();
+  debugPrint('Current streak: $current');
+
+  // ❓ Check if the streak is broken
+  final isBroken = await streak.isStreakBroken();
+  debugPrint('Is streak broken? $isBroken');
+
+  // 📅 Check when the streak will break next
+  final nextReset = await streak.nextResetTime();
+  debugPrint('Next reset time: $nextReset');
+
+  // 📈 Get percent of time remaining before streak breaks
+  final percentLeft = await streak.percentRemaining();
+  debugPrint(
+      'Percent of time remaining: ${(percentLeft! * 100).toStringAsFixed(2)}%');
+
+  // ⏱ Check how long ago the last bump happened
+  final age = await streak.streakAge();
+  debugPrint('Time since last bump: ${age?.inHours} hours');
+
+  // 🏆 Get best streak ever
+  final best = await streak.records.getBestRecord();
+  debugPrint('Best streak ever: $best');
+
+  // 🧯 Reset the streak
+  await streak.reset();
+  debugPrint('Streak reset!');
+
+  // 🧪 Debug helpers
+  final hasData = await streak.hasState();
+  debugPrint('Has saved state? $hasData');
+
+  await streak.clear();
+  debugPrint('State cleared!');
+}

--- a/lib/core/base_counter.dart
+++ b/lib/core/base_counter.dart
@@ -48,7 +48,9 @@ abstract class BaseCounterService extends BaseTrackerService<int> {
   ///
   /// This method sets the counter value to the fallback value, which is
   /// defined as zero, without altering the last update timestamp.
-  Future<void> clearValueOnly() => value.set(fallbackValue());
+  Future<void> clearValueOnly() => _lock.synchronized(() async {
+        await value.set(fallbackValue());
+      });
 
   /// Retrieves the current raw counter value without checking expiration.
   ///

--- a/lib/services/basic_counter.dart
+++ b/lib/services/basic_counter.dart
@@ -1,0 +1,37 @@
+import 'package:prf/prf.dart';
+import 'package:synchronized/synchronized.dart';
+import 'package:track/track.dart';
+
+/// A simple persistent counter with no expiration or periodic reset.
+///
+/// `BasicCounter` lets you increment, reset, and query a counter value
+/// without worrying about time windows, periods, or rollover logic.
+///
+/// Example:
+/// ```dart
+/// final counter = BasicCounter('my_counter');
+/// await counter.increment();
+/// final value = await counter.get();
+/// print('Current count: $value');
+/// ```
+class BasicCounter extends BaseCounterService {
+  final Lock _lock = Lock();
+
+  /// Creates a [BasicCounter] with the specified [key].
+  ///
+  /// Optionally, enable [useCache] for in-memory caching (non-isolate-safe).
+  BasicCounter(super.key, {super.useCache}) : super(suffix: 'basic');
+
+  /// BasicCounter never expires.
+  @override
+  bool isExpired(DateTime now, DateTime? last) => false;
+
+  /// Resets the counter value to zero.
+  @override
+  Future<void> reset() => _lock.synchronized(() async {
+        await Future.wait([
+          value.set(fallbackValue()),
+          lastUpdate.set(DateTime.now()),
+        ]);
+      });
+}

--- a/lib/services/best_record.dart
+++ b/lib/services/best_record.dart
@@ -1,0 +1,205 @@
+import 'package:prf/prf.dart';
+import 'package:synchronized/synchronized.dart';
+import 'package:equatable/equatable.dart';
+import 'package:track/track.dart';
+
+/// Represents a record entry with a numerical value and a timestamp.
+class RecordEntry extends Equatable {
+  /// The numerical value associated with this record.
+  final num value;
+
+  /// The timestamp indicating when this record was created.
+  final DateTime date;
+
+  /// Constructs a [RecordEntry] with the specified [value] and [date].
+  const RecordEntry(this.value, this.date);
+
+  /// Serializes this [RecordEntry] to a JSON-compatible map.
+  Map<String, dynamic> toJson() =>
+      {'value': value, 'date': date.toIso8601String()};
+
+  /// Deserializes a JSON map into a [RecordEntry] instance.
+  factory RecordEntry.fromJson(Map<String, dynamic> json) => RecordEntry(
+        json['value'],
+        DateTime.parse(json['date']),
+      );
+
+  /// Creates a copy of this [RecordEntry] with optional new values.
+  RecordEntry copyWith({num? value, DateTime? date}) =>
+      RecordEntry(value ?? this.value, date ?? this.date);
+
+  @override
+  List<Object> get props => [value, date];
+
+  @override
+  String toString() => 'RecordEntry(value: $value, date: $date)';
+}
+
+/// Defines the mode of record tracking.
+enum RecordMode {
+  /// Track the maximum value.
+  max,
+
+  /// Track the minimum value.
+  min
+}
+
+/// Manages records, allowing storage and retrieval of the best record.
+class BestRecord extends BaseServiceObject {
+  /// The history of recorded entries.
+  final HistoryTracker<RecordEntry> _history;
+
+  /// The mode of record tracking, either [RecordMode.max] or [RecordMode.min].
+  final RecordMode mode;
+
+  /// An optional fallback record entry to use if no records exist.
+  final RecordEntry? fallback;
+
+  /// A lock to ensure thread-safe operations.
+  final _lock = Lock();
+
+  /// Constructs a [BestRecord] with the specified parameters.
+  ///
+  /// [key] is the unique identifier for the record history.
+  /// [mode] specifies whether to track the maximum or minimum value.
+  /// [historyLength] defines the maximum length of the history.
+  /// [fallback] is an optional fallback record entry.
+  /// [useCache] determines whether to use caching.
+  BestRecord(
+    String key, {
+    this.mode = RecordMode.max,
+    int historyLength = 1,
+    this.fallback,
+    super.useCache = false,
+  }) : _history = HistoryTracker.json<RecordEntry>(
+          key,
+          fromJson: (json) => RecordEntry.fromJson(json),
+          toJson: (record) => record.toJson(),
+          maxLength: historyLength,
+          deduplicate: false,
+          useCache: useCache,
+        );
+
+  /// Updates the tracker with a new value, recording it if it's the best.
+  ///
+  /// [newValue] is the new value to be considered for recording.
+  Future<void> update(num newValue) async {
+    await _lock.synchronized(() async {
+      final currentBest = await getBest();
+      final isBetter = currentBest == null ||
+          (mode == RecordMode.max && newValue > currentBest.value) ||
+          (mode == RecordMode.min && newValue < currentBest.value);
+      if (isBetter) {
+        await _history.add(RecordEntry(newValue, DateTime.now()));
+      }
+    });
+  }
+
+  /// Retrieves the best record entry.
+  ///
+  /// Returns the best [RecordEntry] or null if no records exist.
+  Future<RecordEntry?> getBest() async {
+    final records = await _history.getAll();
+    return records.firstOrNull;
+  }
+
+  /// Retrieves the value of the best record entry.
+  ///
+  /// Returns the value of the best record or null if no records exist.
+  Future<num?> getBestRecord() async {
+    final best = await getBest();
+    return best?.value;
+  }
+
+  /// Retrieves the date of the best record entry.
+  ///
+  /// Returns the date of the best record or null if no records exist.
+  Future<DateTime?> getBestDate() async {
+    final best = await getBest();
+    return best?.date;
+  }
+
+  /// Retrieves the full history of records, with the most recent first.
+  ///
+  /// Returns a list of [RecordEntry] objects.
+  Future<List<RecordEntry>> getHistory() async {
+    return await _history.getAll();
+  }
+
+  /// Resets all records in the tracker.
+  Future<void> reset() async {
+    await _lock.synchronized(() => _history.clear());
+  }
+
+  /// Removes the persisted key from storage.
+  Future<void> removeKey() async {
+    await _lock.synchronized(() => _history.removeKey());
+  }
+
+  /// Checks if the record key exists in storage.
+  ///
+  /// Returns true if the key exists, false otherwise.
+  Future<bool> exists() async {
+    return await _history.exists();
+  }
+
+  /// Retrieves the best record entry or the fallback if no best exists.
+  ///
+  /// Returns the best [RecordEntry] or the fallback if no best exists.
+  /// Throws a [StateError] if neither a best record nor a fallback is available.
+  Future<RecordEntry> getBestOrFallback() async {
+    final best = await getBest();
+    if (best != null) return best;
+    if (fallback != null) return fallback!;
+    throw StateError('No record found and no fallback provided.');
+  }
+
+  /// Manually sets a new record entry with the given value.
+  ///
+  /// [value] is the value to be recorded.
+  Future<void> manualSet(num value) async {
+    await _lock.synchronized(() async {
+      await _history.add(RecordEntry(value, DateTime.now()));
+    });
+  }
+
+  /// Removes a record entry at the specified index.
+  ///
+  /// [index] is the position of the record to be removed.
+  Future<void> removeAt(int index) async {
+    await _lock.synchronized(() async {
+      final records = await _history.getAll();
+      if (index >= 0 && index < records.length) {
+        records.removeAt(index);
+        await _history.setAll(records);
+      }
+    });
+  }
+
+  /// Removes record entries that match the given predicate.
+  ///
+  /// [predicate] is a function that returns true for records to be removed.
+  Future<void> removeWhere(bool Function(RecordEntry) predicate) async {
+    await _lock.synchronized(() async {
+      final records = await _history.getAll();
+      records.removeWhere(predicate);
+      await _history.setAll(records);
+    });
+  }
+
+  /// Retrieves the first record entry in the history.
+  ///
+  /// Returns the first [RecordEntry] or null if no records exist.
+  Future<RecordEntry?> first() async {
+    final records = await _history.getAll();
+    return records.firstOrNull;
+  }
+
+  /// Retrieves the last record entry in the history.
+  ///
+  /// Returns the last [RecordEntry] or null if no records exist.
+  Future<RecordEntry?> last() async {
+    final records = await _history.getAll();
+    return records.lastOrNull;
+  }
+}

--- a/lib/services/best_record.dart
+++ b/lib/services/best_record.dart
@@ -72,7 +72,7 @@ class BestRecord extends BaseServiceObject {
     this.fallback,
     super.useCache = false,
   }) : _history = HistoryTracker.json<RecordEntry>(
-          key,
+          "best_record_$key",
           fromJson: (json) => RecordEntry.fromJson(json),
           toJson: (record) => record.toJson(),
           maxLength: historyLength,
@@ -85,7 +85,7 @@ class BestRecord extends BaseServiceObject {
   /// [newValue] is the new value to be considered for recording.
   Future<void> update(num newValue) async {
     await _lock.synchronized(() async {
-      final currentBest = await getBest();
+      final currentBest = await getBestEntry();
       final isBetter = currentBest == null ||
           (mode == RecordMode.max && newValue > currentBest.value) ||
           (mode == RecordMode.min && newValue < currentBest.value);
@@ -98,7 +98,7 @@ class BestRecord extends BaseServiceObject {
   /// Retrieves the best record entry.
   ///
   /// Returns the best [RecordEntry] or null if no records exist.
-  Future<RecordEntry?> getBest() async {
+  Future<RecordEntry?> getBestEntry() async {
     final records = await _history.getAll();
     return records.firstOrNull;
   }
@@ -107,7 +107,7 @@ class BestRecord extends BaseServiceObject {
   ///
   /// Returns the value of the best record or null if no records exist.
   Future<num?> getBestRecord() async {
-    final best = await getBest();
+    final best = await getBestEntry();
     return best?.value;
   }
 
@@ -115,7 +115,7 @@ class BestRecord extends BaseServiceObject {
   ///
   /// Returns the date of the best record or null if no records exist.
   Future<DateTime?> getBestDate() async {
-    final best = await getBest();
+    final best = await getBestEntry();
     return best?.date;
   }
 
@@ -148,7 +148,7 @@ class BestRecord extends BaseServiceObject {
   /// Returns the best [RecordEntry] or the fallback if no best exists.
   /// Throws a [StateError] if neither a best record nor a fallback is available.
   Future<RecordEntry> getBestOrFallback() async {
-    final best = await getBest();
+    final best = await getBestEntry();
     if (best != null) return best;
     if (fallback != null) return fallback!;
     throw StateError('No record found and no fallback provided.');

--- a/lib/track.dart
+++ b/lib/track.dart
@@ -34,6 +34,7 @@ export 'core/time_period.dart';
 export 'core/time_span.dart';
 export 'extensions/adapter_list_extensions.dart';
 export 'services/activity_counter.dart';
+export 'services/basic_counter.dart';
 export 'services/history_tracker.dart';
 export 'services/periodic_counter.dart';
 export 'services/rollover_counter.dart';

--- a/lib/track.dart
+++ b/lib/track.dart
@@ -38,3 +38,4 @@ export 'services/history_tracker.dart';
 export 'services/periodic_counter.dart';
 export 'services/rollover_counter.dart';
 export 'services/streak_tracker.dart';
+export 'services/best_record.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,10 @@ environment:
   flutter: ">=3.24.0"
 
 dependencies:
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
-  prf: ^2.3.1
+  prf: ^2.4.0
   synchronized: ">=3.2.0 <4.0.0"
 
 dev_dependencies:

--- a/test/services/basic_counter_test.dart
+++ b/test/services/basic_counter_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prf/prf.dart';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:track/track.dart';
+
+import '../utils/fake_prefs.dart';
+
+void main() {
+  const testKey = 'test_basic_counter';
+
+  group('BasicCounter', () {
+    (SharedPreferencesAsync, FakeSharedPreferencesAsync) getPreferences() {
+      final store = FakeSharedPreferencesAsync();
+      SharedPreferencesAsyncPlatform.instance = store;
+      final preferences = SharedPreferencesAsync();
+      return (preferences, store);
+    }
+
+    setUp(() async {
+      PrfService.resetOverride();
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+      final counter = BasicCounter(testKey);
+      await counter.clear();
+    });
+
+    test('starts at 0 on first use', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      expect(await counter.get(), 0);
+    });
+
+    test('increments correctly with default amount', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      expect(await counter.increment(), 1);
+      expect(await counter.increment(), 2);
+    });
+
+    test('increments correctly with custom amount', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      expect(await counter.increment(5), 5);
+      expect(await counter.increment(3), 8);
+    });
+
+    test('reset sets value to zero', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      await counter.increment(10);
+      await counter.reset();
+      expect(await counter.get(), 0);
+    });
+
+    test('clearValueOnly sets value to zero without changing lastUpdate',
+        () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      await counter.increment(5);
+      final lastUpdateBefore = await counter.getLastUpdateTime();
+      await counter.clearValueOnly();
+      final lastUpdateAfter = await counter.getLastUpdateTime();
+
+      expect(await counter.get(), 0);
+      expect(lastUpdateBefore, equals(lastUpdateAfter));
+    });
+
+    test('isNonZero returns true if value > 0', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      expect(await counter.isNonZero(), isFalse);
+      await counter.increment();
+      expect(await counter.isNonZero(), isTrue);
+    });
+
+    test('raw returns current value without expiration check', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      await counter.increment(7);
+      expect(await counter.raw(), 7);
+    });
+
+    test('hasState returns true after increment', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final counter = BasicCounter(testKey);
+      expect(await counter.hasState(), isFalse);
+      await counter.increment();
+      expect(await counter.hasState(), isTrue);
+    });
+  });
+}

--- a/test/services/best_record_test.dart
+++ b/test/services/best_record_test.dart
@@ -31,7 +31,7 @@ void main() {
       PrfService.overrideWith(prefs);
 
       final record = BestRecord(testKey);
-      expect(await record.getBest(), isNull);
+      expect(await record.getBestEntry(), isNull);
       expect(await record.getBestRecord(), isNull);
       expect(await record.getBestDate(), isNull);
     });
@@ -45,7 +45,7 @@ void main() {
       await record.update(10);
       await record.update(7);
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 10);
     });
 
@@ -58,7 +58,7 @@ void main() {
       await record.update(2);
       await record.update(7);
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 2);
     });
 
@@ -89,7 +89,7 @@ void main() {
       final record = BestRecord(testKey);
       await record.manualSet(99);
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 99);
     });
 
@@ -130,7 +130,7 @@ void main() {
       await record.update(5);
       await record.reset();
 
-      expect(await record.getBest(), isNull);
+      expect(await record.getBestEntry(), isNull);
     });
 
     test('removeKey deletes preferences key', () async {
@@ -162,7 +162,7 @@ void main() {
 
       {
         final record = BestRecord(testKey);
-        final best = await record.getBest();
+        final best = await record.getBestEntry();
         expect(best!.value, 10);
       }
     });
@@ -205,7 +205,7 @@ void main() {
       await record.update(100);
       final after = DateTime.now();
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.date.isAfter(before) || best.date.isAtSameMomentAs(before),
           isTrue);
       expect(best.date.isBefore(after) || best.date.isAtSameMomentAs(after),
@@ -243,7 +243,7 @@ void main() {
       final record = BestRecord(testKey, mode: RecordMode.min);
       await record.update(5);
       await record.update(10); // should NOT overwrite best
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 5);
     });
 
@@ -254,7 +254,7 @@ void main() {
       final record = BestRecord(testKey, mode: RecordMode.max);
       await record.update(10);
       await record.update(5); // should NOT overwrite best
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 10);
     });
 
@@ -320,7 +320,7 @@ void main() {
         await record.update(i);
       }
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       final history = await record.getHistory();
 
       expect(best!.value, 99);
@@ -337,7 +337,7 @@ void main() {
 
       await Future.wait(List.generate(20, (i) => record.update(i)));
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 19);
     });
 
@@ -351,7 +351,7 @@ void main() {
       await record.manualSet(8);
       await record.update(12);
 
-      final best = await record.getBest();
+      final best = await record.getBestEntry();
       expect(best!.value, 12);
     });
 
@@ -399,8 +399,8 @@ void main() {
       await recordA.update(10);
       await recordB.update(20);
 
-      final bestA = await recordA.getBest();
-      final bestB = await recordB.getBest();
+      final bestA = await recordA.getBestEntry();
+      final bestB = await recordB.getBestEntry();
 
       expect(bestA!.value, 10);
       expect(bestB!.value, 20);
@@ -417,7 +417,7 @@ void main() {
       final recordMin = BestRecord(testKey, mode: RecordMode.min);
       await recordMin.update(3);
 
-      final bestMin = await recordMin.getBest();
+      final bestMin = await recordMin.getBestEntry();
       expect(bestMin!.value, 3);
     });
 

--- a/test/services/best_record_test.dart
+++ b/test/services/best_record_test.dart
@@ -1,0 +1,441 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prf/prf.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
+import 'package:track/track.dart';
+
+import '../utils/fake_prefs.dart';
+
+void main() {
+  const testKey = 'test_best_record';
+
+  group('BestRecord', () {
+    (SharedPreferencesAsync, FakeSharedPreferencesAsync) getPreferences() {
+      final store = FakeSharedPreferencesAsync();
+      SharedPreferencesAsyncPlatform.instance = store;
+      final preferences = SharedPreferencesAsync();
+      return (preferences, store);
+    }
+
+    setUp(() async {
+      PrfService.resetOverride();
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+      final record = BestRecord(testKey);
+      await record.reset();
+    });
+
+    test('starts empty', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      expect(await record.getBest(), isNull);
+      expect(await record.getBestRecord(), isNull);
+      expect(await record.getBestDate(), isNull);
+    });
+
+    test('records best value in max mode', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.max);
+      await record.update(5);
+      await record.update(10);
+      await record.update(7);
+
+      final best = await record.getBest();
+      expect(best!.value, 10);
+    });
+
+    test('records best value in min mode', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.min);
+      await record.update(5);
+      await record.update(2);
+      await record.update(7);
+
+      final best = await record.getBest();
+      expect(best!.value, 2);
+    });
+
+    test('getBestOrFallback returns fallback if no data', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final fallback = RecordEntry(42, DateTime.now());
+      final record = BestRecord(testKey, fallback: fallback);
+
+      final result = await record.getBestOrFallback();
+      expect(result, fallback);
+    });
+
+    test('getBestOrFallback throws without fallback', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+
+      expect(() => record.getBestOrFallback(), throwsStateError);
+    });
+
+    test('manualSet adds record without comparison', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.manualSet(99);
+
+      final best = await record.getBest();
+      expect(best!.value, 99);
+    });
+
+    test('removeAt deletes entry', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 2);
+      await record.manualSet(10);
+      await record.manualSet(20);
+      var history = await record.getHistory();
+      expect(history.length, 2);
+
+      await record.removeAt(0);
+      history = await record.getHistory();
+      expect(history.length, 1);
+    });
+
+    test('removeWhere deletes matching entries', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.manualSet(10);
+      await record.manualSet(20);
+      await record.removeWhere((entry) => entry.value == 10);
+
+      final history = await record.getHistory();
+      expect(history.length, 1);
+      expect(history.first.value, 20);
+    });
+
+    test('reset clears all records', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.update(5);
+      await record.reset();
+
+      expect(await record.getBest(), isNull);
+    });
+
+    test('removeKey deletes preferences key', () async {
+      final (prefs, store) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.update(5);
+      expect(await record.exists(), isTrue);
+
+      await record.removeKey();
+      expect(await record.exists(), isFalse);
+
+      final keys = await store.getKeys(
+        const GetPreferencesParameters(filter: PreferencesFilters()),
+        const SharedPreferencesOptions(),
+      );
+      expect(keys.any((k) => k.contains(testKey)), isFalse);
+    });
+
+    test('state persists across instances', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      {
+        final record = BestRecord(testKey);
+        await record.update(10);
+      }
+
+      {
+        final record = BestRecord(testKey);
+        final best = await record.getBest();
+        expect(best!.value, 10);
+      }
+    });
+
+    test('first() and last() return correct entries', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 3);
+      await record.manualSet(1);
+      await record.manualSet(2);
+      await record.manualSet(3);
+
+      final first = await record.first();
+      final last = await record.last();
+
+      expect(first!.value, 3); // most recent first
+      expect(last!.value, 1); // oldest last
+    });
+
+    test('history length respects max history setting', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 2);
+      await record.manualSet(1);
+      await record.manualSet(2);
+      await record.manualSet(3);
+
+      final history = await record.getHistory();
+      expect(history.length, 2);
+    });
+
+    test('update sets correct date', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      final before = DateTime.now();
+      await record.update(100);
+      final after = DateTime.now();
+
+      final best = await record.getBest();
+      expect(best!.date.isAfter(before) || best.date.isAtSameMomentAs(before),
+          isTrue);
+      expect(best.date.isBefore(after) || best.date.isAtSameMomentAs(after),
+          isTrue);
+    });
+
+    test('getBestOrFallback works after reset', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final fallback = RecordEntry(999, DateTime.now());
+      final record = BestRecord(testKey, fallback: fallback);
+      await record.manualSet(50);
+      await record.reset();
+
+      final result = await record.getBestOrFallback();
+      expect(result, fallback);
+    });
+
+    test('getBestOrFallback throws after reset if no fallback', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.manualSet(50);
+      await record.reset();
+
+      expect(() => record.getBestOrFallback(), throwsStateError);
+    });
+
+    test('min mode ignores larger values', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.min);
+      await record.update(5);
+      await record.update(10); // should NOT overwrite best
+      final best = await record.getBest();
+      expect(best!.value, 5);
+    });
+
+    test('max mode ignores smaller values', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.max);
+      await record.update(10);
+      await record.update(5); // should NOT overwrite best
+      final best = await record.getBest();
+      expect(best!.value, 10);
+    });
+
+    test('removeAt out of bounds does nothing', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.manualSet(1);
+      await record.removeAt(5); // invalid index
+      final history = await record.getHistory();
+      expect(history.length, 1);
+    });
+
+    test('removeWhere with no matches leaves history intact', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      await record.manualSet(1);
+      await record.removeWhere((entry) => entry.value == 999); // no match
+      final history = await record.getHistory();
+      expect(history.length, 1);
+    });
+
+    test('exists returns correct state', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey);
+      expect(await record.exists(), isFalse);
+
+      await record.manualSet(42);
+      expect(await record.exists(), isTrue);
+
+      await record.removeKey();
+      expect(await record.exists(), isFalse);
+    });
+
+    test('history trims to max length', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 2);
+      await record.manualSet(1);
+      await record.manualSet(2);
+      await record.manualSet(3);
+
+      final history = await record.getHistory();
+      expect(history.length, 2);
+      expect(history.first.value, 3);
+      expect(history.last.value, 2);
+    });
+
+    test('stress test with many updates', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record =
+          BestRecord(testKey, mode: RecordMode.max, historyLength: 10);
+
+      for (int i = 0; i < 100; i++) {
+        await record.update(i);
+      }
+
+      final best = await record.getBest();
+      final history = await record.getHistory();
+
+      expect(best!.value, 99);
+      expect(history.length, 10);
+      expect(history.first.value, 99);
+      expect(history.last.value, 90);
+    });
+
+    test('handles concurrent updates safely', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.max);
+
+      await Future.wait(List.generate(20, (i) => record.update(i)));
+
+      final best = await record.getBest();
+      expect(best!.value, 19);
+    });
+
+    test('mixing manualSet and update keeps best value', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, mode: RecordMode.max);
+      await record.manualSet(5);
+      await record.update(10);
+      await record.manualSet(8);
+      await record.update(12);
+
+      final best = await record.getBest();
+      expect(best!.value, 12);
+    });
+
+    test('history remains ordered after remove operations', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 5);
+      await record.manualSet(1);
+      await record.manualSet(2);
+      await record.manualSet(3);
+
+      await record.removeAt(1); // remove middle
+
+      var history = await record.getHistory();
+      expect(history.map((e) => e.value), [3, 1]);
+
+      await record.removeWhere((e) => e.value == 1);
+
+      history = await record.getHistory();
+      expect(history.map((e) => e.value), [3]);
+    });
+
+    test('fallback works after clearing records with removeWhere', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final fallback = RecordEntry(999, DateTime.now());
+      final record = BestRecord(testKey, fallback: fallback);
+
+      await record.manualSet(10);
+      await record.removeWhere((e) => e.value == 10);
+
+      final result = await record.getBestOrFallback();
+      expect(result, fallback);
+    });
+
+    test('multiple keys are isolated', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final recordA = BestRecord('recordA', mode: RecordMode.max);
+      final recordB = BestRecord('recordB', mode: RecordMode.max);
+
+      await recordA.update(10);
+      await recordB.update(20);
+
+      final bestA = await recordA.getBest();
+      final bestB = await recordB.getBest();
+
+      expect(bestA!.value, 10);
+      expect(bestB!.value, 20);
+    });
+
+    test('switching mode reuses old data but applies new logic', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final recordMax = BestRecord(testKey, mode: RecordMode.max);
+      await recordMax.update(10);
+      await recordMax.update(5);
+
+      final recordMin = BestRecord(testKey, mode: RecordMode.min);
+      await recordMin.update(3);
+
+      final bestMin = await recordMin.getBest();
+      expect(bestMin!.value, 3);
+    });
+
+    test('remove middle, add new, check order', () async {
+      final (prefs, _) = getPreferences();
+      PrfService.overrideWith(prefs);
+
+      final record = BestRecord(testKey, historyLength: 3);
+      await record.manualSet(1);
+      await record.manualSet(2);
+      await record.manualSet(3);
+
+      await record.removeAt(1); // remove second item
+
+      await record.manualSet(4);
+
+      final history = await record.getHistory();
+      expect(history.map((e) => e.value), [4, 3, 1]);
+    });
+  });
+}


### PR DESCRIPTION
### **New services added**:

- 🏅 **BestRecord** — track the best (max or min) performance or value over time, with a full history and fallback support. Example use cases: high scores, fastest times, highest streaks

- 🔢 **BasicCounter** — a simple persistent counter with no expiration or alignment. Example use cases: total taps, visits, or actions

### **Enhancements**:

- 🔥 **StreakTracker now integrates BestRecord**
  - Automatically tracks and saves the highest streak ever achieved
  - Supports history length, fallback records, and customizable record mode (`max` or `min`)

### Fixed:

- **Synchronized `clearValueOnly()` in BaseCounterService**  
  Now uses `_lock.synchronized()` to prevent race conditions, ensuring thread safety like `increment()` and `reset()`.
